### PR TITLE
Add [make:enum] command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,11 @@
     "extra": {
         "branch-alias": {
             "dev-master": "1.2-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Konekt\\Enum\\Eloquent\\EnumServiceProvider"
+            ]
         }
     }
 }

--- a/src/Commands/EnumMakeCommand.php
+++ b/src/Commands/EnumMakeCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Konekt\Enum\Eloquent\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class EnumMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:enum';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new enum class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Enum';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('labels')) {
+            return __DIR__.'/stubs/enum.labels.stub';
+        }
+
+        if ($this->option('boot')) {
+            return __DIR__.'/stubs/enum.boot.stub';
+        }
+
+        return __DIR__.'/stubs/enum.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Enums';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['labels', 'l', InputOption::VALUE_NONE, 'Create an Enum class with predefined labels'],
+
+            ['boot', 'b', InputOption::VALUE_NONE, 'Create an Enum class with [boot] method'],
+        ];
+    }
+}

--- a/src/Commands/stubs/enum.boot.stub
+++ b/src/Commands/stubs/enum.boot.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace DummyNamespace;
+
+use Konekt\Enum\Enum;
+
+class DummyClass extends Enum
+{
+    const __default = self::OPTION_ONE;
+
+    const OPTION_ONE = 'option_one';
+    const OPTION_TWO = 'option_two';
+
+    public static $labels = [];
+
+    protected static function boot()
+    {
+        static::$labels = [
+            self::OPTION_ONE => __('Option #1'),
+            self::OPTION_TWO => __('Option #2'),
+        ];
+    }
+}

--- a/src/Commands/stubs/enum.labels.stub
+++ b/src/Commands/stubs/enum.labels.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace DummyNamespace;
+
+use Konekt\Enum\Enum;
+
+class DummyClass extends Enum
+{
+    const __default = self::OPTION_ONE;
+
+    const OPTION_ONE = 'option_one';
+    const OPTION_TWO = 'option_two';
+
+    public static $labels = [
+        self::OPTION_ONE => 'Option #1',
+        self::OPTION_TWO => 'Option #2',
+    ];
+}

--- a/src/Commands/stubs/enum.stub
+++ b/src/Commands/stubs/enum.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace DummyNamespace;
+
+use Konekt\Enum\Enum;
+
+class DummyClass extends Enum
+{
+    const __default = self::OPTION_ONE;
+
+    const OPTION_ONE = 'option_one';
+    const OPTION_TWO = 'option_two';
+}

--- a/src/EnumServiceProvider.php
+++ b/src/EnumServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Konekt\Enum\Eloquent;
+
+use Illuminate\Support\ServiceProvider;
+
+class EnumServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Commands\EnumMakeCommand::class,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds [make:enum] command with 2 possible options:

- _-l, --labels_
Creates an enum class with predefined labels

- _-b, --boot_
Creates an enum class with `boot()` method. Option is useful to generate enum with translatable labels.