### PR TITLE
Feature/5 add enum v3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
     env: LARAVEL=5.6
   - php: 7.1
     env: LARAVEL=5.7
+  - php: 7.1
+    env: LARAVEL=5.8
   - php: 7.2
     env: LARAVEL=5.4
   - php: 7.2
@@ -38,6 +40,8 @@ matrix:
     env: LARAVEL=5.6
   - php: 7.2
     env: LARAVEL=5.7
+  - php: 7.2
+    env: LARAVEL=5.8
   - php: 7.3
     env: LARAVEL=5.4
   - php: 7.3
@@ -46,6 +50,8 @@ matrix:
     env: LARAVEL=5.6
   - php: 7.3
     env: LARAVEL=5.7
+  - php: 7.3
+    env: LARAVEL=5.8
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,55 +4,26 @@ cache:
   directories:
   - "$HOME/.composer/cache"
 
+php:
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+
 env:
-- ENUM=3
-- ENUM=2
-
-matrix:
-  include:
-  - php: 7.0
-    env: LARAVEL=5.0
-  - php: 7.0
-    env: LARAVEL=5.1
-  - php: 7.0
-    env: LARAVEL=5.2
-  - php: 7.0
-    env: LARAVEL=5.3
-  - php: 7.0
-    env: LARAVEL=5.4
-  - php: 7.0
-    env: LARAVEL=5.5
-  - php: 7.1
-    env: LARAVEL=5.4
-  - php: 7.1
-    env: LARAVEL=5.5
-  - php: 7.1
-    env: LARAVEL=5.6
-  - php: 7.1
-    env: LARAVEL=5.7
-  - php: 7.1
-    env: LARAVEL=5.8
-  - php: 7.2
-    env: LARAVEL=5.4
-  - php: 7.2
-    env: LARAVEL=5.5
-  - php: 7.2
-    env: LARAVEL=5.6
-  - php: 7.2
-    env: LARAVEL=5.7
-  - php: 7.2
-    env: LARAVEL=5.8
-  - php: 7.3
-    env: LARAVEL=5.4
-  - php: 7.3
-    env: LARAVEL=5.5
-  - php: 7.3
-    env: LARAVEL=5.6
-  - php: 7.3
-    env: LARAVEL=5.7
-  - php: 7.3
-    env: LARAVEL=5.8
-
+  global:
+    - ENUM=2
+    - ENUM=3
+  matrix:  
+    - LARAVEL=5.0
+    - LARAVEL=5.1
+    - LARAVEL=5.2
+    - LARAVEL=5.3
+    - LARAVEL=5.4
+    - LARAVEL=5.5
+    - LARAVEL=5.6
+    - LARAVEL=5.7
+    - LARAVEL=5.8
 
 script:
 - vendor/bin/phpunit -c phpunit.xml tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,6 @@ matrix:
     env: ENUM=2 LARAVEL=5.3
   - php: 7.0
     env: ENUM=2 LARAVEL=5.4
-  - php: 7.0
-    env: ENUM=3 LARAVEL=5.0
-  - php: 7.0
-    env: ENUM=3 LARAVEL=5.1
-  - php: 7.0
-    env: ENUM=3 LARAVEL=5.2
-  - php: 7.0
-    env: ENUM=3 LARAVEL=5.3
-  - php: 7.0
-    env: ENUM=3 LARAVEL=5.4
 
 script:
 - vendor/bin/phpunit -c phpunit.xml tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,55 @@ cache:
   directories:
   - "$HOME/.composer/cache"
 
-php:
-  - '7.0'
-  - '7.1'
-  - '7.2'
-  - '7.3'
-
 env:
-  global:
+  matrix:
     - ENUM=2
     - ENUM=3
-  matrix:  
-    - LARAVEL=5.0
-    - LARAVEL=5.1
-    - LARAVEL=5.2
-    - LARAVEL=5.3
-    - LARAVEL=5.4
-    - LARAVEL=5.5
-    - LARAVEL=5.6
-    - LARAVEL=5.7
-    - LARAVEL=5.8
+    
+matrix:
+  include:
+  - php: 7.0
+    env: LARAVEL=5.0
+  - php: 7.0
+    env: LARAVEL=5.1
+  - php: 7.0
+    env: LARAVEL=5.2
+  - php: 7.0
+    env: LARAVEL=5.3
+  - php: 7.0
+    env: LARAVEL=5.4
+  - php: 7.0
+    env: LARAVEL=5.5
+  - php: 7.1
+    env: LARAVEL=5.4
+  - php: 7.1
+    env: LARAVEL=5.5
+  - php: 7.1
+    env: LARAVEL=5.6
+  - php: 7.1
+    env: LARAVEL=5.7
+  - php: 7.1
+    env: LARAVEL=5.8
+  - php: 7.2
+    env: LARAVEL=5.4
+  - php: 7.2
+    env: LARAVEL=5.5
+  - php: 7.2
+    env: LARAVEL=5.6
+  - php: 7.2
+    env: LARAVEL=5.7
+  - php: 7.2
+    env: LARAVEL=5.8
+  - php: 7.3
+    env: LARAVEL=5.4
+  - php: 7.3
+    env: LARAVEL=5.5
+  - php: 7.3
+    env: LARAVEL=5.6
+  - php: 7.3
+    env: LARAVEL=5.7
+  - php: 7.3
+    env: LARAVEL=5.8
 
 script:
 - vendor/bin/phpunit -c phpunit.xml tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,55 +4,45 @@ cache:
   directories:
   - "$HOME/.composer/cache"
 
+php:
+  - '7.1'
+  - '7.2'
+  - '7.3'
+
 env:
-  matrix:
-    - ENUM=2
-    - ENUM=3
-    
+  - ENUM=2 LARAVEL=5.4
+  - ENUM=2 LARAVEL=5.5
+  - ENUM=2 LARAVEL=5.6
+  - ENUM=2 LARAVEL=5.7
+  - ENUM=2 LARAVEL=5.8
+  - ENUM=3 LARAVEL=5.4
+  - ENUM=3 LARAVEL=5.5
+  - ENUM=3 LARAVEL=5.6
+  - ENUM=3 LARAVEL=5.7
+  - ENUM=3 LARAVEL=5.8
+      
 matrix:
   include:
   - php: 7.0
-    env: LARAVEL=5.0
+    env: ENUM=2 LARAVEL=5.0
   - php: 7.0
-    env: LARAVEL=5.1
+    env: ENUM=2 LARAVEL=5.1
   - php: 7.0
-    env: LARAVEL=5.2
+    env: ENUM=2 LARAVEL=5.2
   - php: 7.0
-    env: LARAVEL=5.3
+    env: ENUM=2 LARAVEL=5.3
   - php: 7.0
-    env: LARAVEL=5.4
+    env: ENUM=2 LARAVEL=5.4
   - php: 7.0
-    env: LARAVEL=5.5
-  - php: 7.1
-    env: LARAVEL=5.4
-  - php: 7.1
-    env: LARAVEL=5.5
-  - php: 7.1
-    env: LARAVEL=5.6
-  - php: 7.1
-    env: LARAVEL=5.7
-  - php: 7.1
-    env: LARAVEL=5.8
-  - php: 7.2
-    env: LARAVEL=5.4
-  - php: 7.2
-    env: LARAVEL=5.5
-  - php: 7.2
-    env: LARAVEL=5.6
-  - php: 7.2
-    env: LARAVEL=5.7
-  - php: 7.2
-    env: LARAVEL=5.8
-  - php: 7.3
-    env: LARAVEL=5.4
-  - php: 7.3
-    env: LARAVEL=5.5
-  - php: 7.3
-    env: LARAVEL=5.6
-  - php: 7.3
-    env: LARAVEL=5.7
-  - php: 7.3
-    env: LARAVEL=5.8
+    env: ENUM=3 LARAVEL=5.0
+  - php: 7.0
+    env: ENUM=3 LARAVEL=5.1
+  - php: 7.0
+    env: ENUM=3 LARAVEL=5.2
+  - php: 7.0
+    env: ENUM=3 LARAVEL=5.3
+  - php: 7.0
+    env: ENUM=3 LARAVEL=5.4
 
 script:
 - vendor/bin/phpunit -c phpunit.xml tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ cache:
   directories:
   - "$HOME/.composer/cache"
 
+env:
+- ENUM=3
+- ENUM=2
+
 matrix:
   include:
   - php: 7.0
@@ -48,6 +52,7 @@ script:
 - vendor/bin/phpunit -c phpunit.xml tests/
 
 before_install:
+- composer require "konekt/enum:${ENUM}.*" --no-update -v
 - composer require "illuminate/database:${LARAVEL}.*" --no-update -v
 - composer require "illuminate/events:${LARAVEL}.*" --no-update -v
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 
 - Added make:enum commands (when using in a Laravel application)
 - Enum 3.0.0 is supported
+- Updated references to https://konekt.dev/enum website
 
 ## 1.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 ### Unreleased
 
 - Added make:enum commands (when using in a Laravel application)
+- Enum 3.0.0 is supported
 
 ## 1.2
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This package provides support for auto casting [konekt enum](https://github.com/artkonekt/enum) fields in [Eloquent models](https://laravel.com/docs/5.4/eloquent-mutators).
 
-> Supported Konekt Enum versions are 2.0+ and Eloquent 5.0+
+> Supported Konekt Enum versions are 2.0+ or 3.0+ and Eloquent 5.0+
 
 [Changelog](Changelog.md)
 
@@ -33,7 +33,8 @@ use Konekt\Enum\Enum;
 
 class OrderStatus extends Enum
 {
-    const __default = self::PENDING;
+    const __DEFAULT = self::PENDING; 
+    // const __default = self::PENDING; // usage of default in v2.x 
 
     const PENDING   = 'pending';
     const CANCELLED = 'cancelled';

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![StyleCI](https://styleci.io/repos/105900484/shield?branch=master)](https://styleci.io/repos/105900484)
 [![MIT Software License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.md)
 
-This package provides support for auto casting [konekt enum](https://github.com/artkonekt/enum) fields in [Eloquent models](https://laravel.com/docs/5.4/eloquent-mutators).
+This package provides support for auto casting [konekt enum](https://konekt.dev/enum) fields in [Eloquent models](https://laravel.com/docs/5.4/eloquent-mutators).
 
 > Supported Konekt Enum versions are 2.0+ or 3.0+ and Eloquent 5.0+
 
@@ -171,4 +171,4 @@ used by the forms library to obtain form field value.
 
 Enjoy!
 
-For detailed usage of konekt enums refer to the [Konekt Enum Documentation](https://artkonekt.github.io/enum).
+For detailed usage of konekt enums refer to the [Konekt Enum Documentation](https://konekt.dev/enum).

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "6.3 - 7.4",
         "illuminate/events": "5.*",
-        "ocramius/package-versions": "^1.4"
+        "ocramius/package-versions": "^1.2"
     },
     "autoload": {
         "psr-4": { "Konekt\\Enum\\Eloquent\\": "src/" },

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,13 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "konekt/enum": "^2.0.2",
+        "konekt/enum": "^2.0.2 || ^3.0.0",
         "illuminate/database": "5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "6.3 - 7.4",
-        "illuminate/events": "5.*"
+        "illuminate/events": "5.*",
+        "ocramius/package-versions": "^1.4"
     },
     "autoload": {
         "psr-4": { "Konekt\\Enum\\Eloquent\\": "src/" },

--- a/src/Commands/stubs/enum.boot.stub
+++ b/src/Commands/stubs/enum.boot.stub
@@ -6,7 +6,8 @@ use Konekt\Enum\Enum;
 
 class DummyClass extends Enum
 {
-    const __default = self::OPTION_ONE;
+    const __DEFAULT = self::OPTION_ONE;
+    // const __default = self::OPTION_ONE; // default for v2
 
     const OPTION_ONE = 'option_one';
     const OPTION_TWO = 'option_two';

--- a/src/Commands/stubs/enum.labels.stub
+++ b/src/Commands/stubs/enum.labels.stub
@@ -6,7 +6,8 @@ use Konekt\Enum\Enum;
 
 class DummyClass extends Enum
 {
-    const __default = self::OPTION_ONE;
+    const __DEFAULT = self::OPTION_ONE;
+    // const __default = self::OPTION_ONE; // default for v2
 
     const OPTION_ONE = 'option_one';
     const OPTION_TWO = 'option_two';

--- a/src/Commands/stubs/enum.stub
+++ b/src/Commands/stubs/enum.stub
@@ -6,7 +6,8 @@ use Konekt\Enum\Enum;
 
 class DummyClass extends Enum
 {
-    const __default = self::OPTION_ONE;
+    const __DEFAULT = self::OPTION_ONE;
+    // const __default = self::OPTION_ONE; // default for v2
 
     const OPTION_ONE = 'option_one';
     const OPTION_TWO = 'option_two';

--- a/tests/EnumAccessorTest.php
+++ b/tests/EnumAccessorTest.php
@@ -15,6 +15,10 @@ namespace Konekt\Enum\Eloquent\Tests;
 use Konekt\Enum\Eloquent\Tests\Models\Client;
 use Konekt\Enum\Eloquent\Tests\Models\Order;
 use Konekt\Enum\Eloquent\Tests\Models\OrderStatus;
+use Konekt\Enum\Eloquent\Tests\Models\OrderV2;
+use Konekt\Enum\Eloquent\Tests\Models\OrderStatusV2;
+use Konekt\Enum\Eloquent\Tests\Models\OrderVX;
+use Konekt\Enum\Eloquent\Tests\Models\OrderStatusVX;
 
 class EnumAccessorTest extends TestCase
 {
@@ -38,12 +42,53 @@ class EnumAccessorTest extends TestCase
      */
     public function it_returns_the_enum_default_when_attribute_is_null()
     {
+        // don't test if mayor version is lower than 3
+        if ($this->getEnumVersionMayor() < 3)
+        {
+            $this->assertTrue(true);
+            return;
+        }
+        
         $order = new Order([
             'number' => 'PLGU7S5'
         ]);
 
         $this->assertInstanceOf(OrderStatus::class, $order->status);
-        $this->assertEquals(OrderStatus::__default, $order->status->value());
+        $this->assertEquals(OrderStatus::__DEFAULT, $order->status->value());
+    }
+    
+    /**
+     * @test
+     */
+    public function it_returns_the_enum_v2_default_when_attribute_is_null()
+    {
+        // don't test if mayor version is 3 or higher
+        if ($this->getEnumVersionMayor() >= 3)
+        {
+            $this->assertTrue(true);
+            return;
+        }
+        
+        $order = new OrderV2([
+            'number' => 'PLGU7S5'
+        ]);
+
+        $this->assertInstanceOf(OrderStatusV2::class, $order->status);
+        $this->assertEquals(OrderStatusV2::__default, $order->status->value());
+    }
+        
+    /**
+     * @test
+     */
+    public function it_returns_the_enum_backwards_compatible_default_when_attribute_is_null()
+    {
+        $order = new OrderVX([
+            'number' => 'PLGU7S5'
+        ]);
+
+        $this->assertInstanceOf(OrderStatusVX::class, $order->status);
+        $this->assertEquals(OrderStatusVX::__DEFAULT, $order->status->value());
+        $this->assertEquals(OrderStatusVX::__default, $order->status->value());
     }
 
     /**
@@ -91,5 +136,21 @@ class EnumAccessorTest extends TestCase
 
         $this->assertInstanceOf(Client::class, $order->client);
         $this->assertEquals($client->id, $order->client->id);
+    }
+    
+    private function getEnumVersion()
+    {
+        $raw_version = \PackageVersions\Versions::getVersion('konekt/enum');
+        
+        $parts = explode('@', $raw_version);
+        
+        return $parts[0];
+    }
+    
+    private function getEnumVersionMayor()
+    {
+        $parts = explode('.', $this->getEnumVersion());
+        
+        return $parts[0];
     }
 }

--- a/tests/EnumAccessorTest.php
+++ b/tests/EnumAccessorTest.php
@@ -43,7 +43,7 @@ class EnumAccessorTest extends TestCase
     public function it_returns_the_enum_default_when_attribute_is_null()
     {
         // don't test if mayor version is lower than 3
-        if ($this->getEnumVersionMayor() < 3) {
+        if ($this->getEnumVersionMajor() < 3) {
             $this->assertTrue(true);
             return;
         }
@@ -62,7 +62,7 @@ class EnumAccessorTest extends TestCase
     public function it_returns_the_enum_v2_default_when_attribute_is_null()
     {
         // don't test if mayor version is 3 or higher
-        if ($this->getEnumVersionMayor() >= 3) {
+        if ($this->getEnumVersionMajor() >= 3) {
             $this->assertTrue(true);
             return;
         }
@@ -145,7 +145,7 @@ class EnumAccessorTest extends TestCase
         return $parts[0];
     }
     
-    private function getEnumVersionMayor()
+    private function getEnumVersionMajor()
     {
         $parts = explode('.', $this->getEnumVersion());
         

--- a/tests/EnumAccessorTest.php
+++ b/tests/EnumAccessorTest.php
@@ -43,8 +43,7 @@ class EnumAccessorTest extends TestCase
     public function it_returns_the_enum_default_when_attribute_is_null()
     {
         // don't test if mayor version is lower than 3
-        if ($this->getEnumVersionMayor() < 3)
-        {
+        if ($this->getEnumVersionMayor() < 3) {
             $this->assertTrue(true);
             return;
         }
@@ -63,8 +62,7 @@ class EnumAccessorTest extends TestCase
     public function it_returns_the_enum_v2_default_when_attribute_is_null()
     {
         // don't test if mayor version is 3 or higher
-        if ($this->getEnumVersionMayor() >= 3)
-        {
+        if ($this->getEnumVersionMayor() >= 3) {
             $this->assertTrue(true);
             return;
         }

--- a/tests/Models/AddressStatus.php
+++ b/tests/Models/AddressStatus.php
@@ -16,7 +16,8 @@ use Konekt\Enum\Enum;
 
 class AddressStatus extends Enum
 {
-    const __default = self::UNKNOWN;
+    const __DEFAULT = self::UNKNOWN;
+    const __default = self::UNKNOWN; // v2 default for backwards compatibility
 
     const UNKNOWN   = null;
     const VALID     = 'valid';

--- a/tests/Models/AddressStatus.php
+++ b/tests/Models/AddressStatus.php
@@ -16,9 +16,6 @@ use Konekt\Enum\Enum;
 
 class AddressStatus extends Enum
 {
-    const __DEFAULT = self::UNKNOWN;
-    const __default = self::UNKNOWN; // v2 default for backwards compatibility
-
     const UNKNOWN   = null;
     const VALID     = 'valid';
     const INVALID   = 'invalid';

--- a/tests/Models/EloquentType.php
+++ b/tests/Models/EloquentType.php
@@ -16,9 +16,6 @@ use Konekt\Enum\Enum;
 
 class EloquentType extends Enum
 {
-    const __DEFAULT = self::NADA;
-    const __default = self::NADA; // v2 default for backwards compatibility
-
     const NADA      = null;
     const WHATEVER  = 'whatever';
     const NEVERMIND = 'nevermind';

--- a/tests/Models/EloquentType.php
+++ b/tests/Models/EloquentType.php
@@ -16,7 +16,8 @@ use Konekt\Enum\Enum;
 
 class EloquentType extends Enum
 {
-    const __default = self::NADA;
+    const __DEFAULT = self::NADA;
+    const __default = self::NADA; // v2 default for backwards compatibility
 
     const NADA      = null;
     const WHATEVER  = 'whatever';

--- a/tests/Models/OrderStatusV2.php
+++ b/tests/Models/OrderStatusV2.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Contains the OrderStatus class.
+ * Contains the OrderStatus class with Enum version 2 default 
  *
  * @copyright   Copyright (c) 2017 Attila Fulop
- * @author      Attila Fulop
+ * @author      Mark Boessenkool
  * @license     MIT
- * @since       2017-10-05
+ * @since       2019-09-03
  *
  */
 

--- a/tests/Models/OrderStatusV2.php
+++ b/tests/Models/OrderStatusV2.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains the OrderStatus class with Enum version 2 default 
+ * Contains the OrderStatus class with Enum version 2 default.
  *
  * @copyright   Copyright (c) 2017 Attila Fulop
  * @author      Mark Boessenkool

--- a/tests/Models/OrderStatusV2.php
+++ b/tests/Models/OrderStatusV2.php
@@ -14,9 +14,9 @@ namespace Konekt\Enum\Eloquent\Tests\Models;
 
 use Konekt\Enum\Enum;
 
-class OrderStatus extends Enum
+class OrderStatusV2 extends Enum
 {
-    const __DEFAULT = self::SUBMITTED;
+    const __default = self::SUBMITTED;
 
     const SUBMITTED  = 'submitted';
     const PROCESSING = 'processing';

--- a/tests/Models/OrderStatusVX.php
+++ b/tests/Models/OrderStatusVX.php
@@ -14,9 +14,10 @@ namespace Konekt\Enum\Eloquent\Tests\Models;
 
 use Konekt\Enum\Enum;
 
-class OrderStatus extends Enum
+class OrderStatusVX extends Enum
 {
     const __DEFAULT = self::SUBMITTED;
+    const __default = self::SUBMITTED; // v2 default for backwards compatibility
 
     const SUBMITTED  = 'submitted';
     const PROCESSING = 'processing';

--- a/tests/Models/OrderStatusVX.php
+++ b/tests/Models/OrderStatusVX.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains the OrderStatus class with Enum version 2 and 3 default
+ * Contains the OrderStatus class with Enum version 2 and 3 default.
  *
  * @copyright   Copyright (c) 2017 Attila Fulop
  * @author      Mark Boessenkool

--- a/tests/Models/OrderStatusVX.php
+++ b/tests/Models/OrderStatusVX.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Contains the OrderStatus class.
+ * Contains the OrderStatus class with Enum version 2 and 3 default
  *
  * @copyright   Copyright (c) 2017 Attila Fulop
- * @author      Attila Fulop
+ * @author      Mark Boessenkool
  * @license     MIT
- * @since       2017-10-05
+ * @since       2019-09-03
  *
  */
 

--- a/tests/Models/OrderV2.php
+++ b/tests/Models/OrderV2.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Contains the Order model class.
+ * Contains the Order model class for Enum version 2 default
  *
  * @copyright   Copyright (c) 2017 Attila Fulop
- * @author      Attila Fulop
+ * @author      Mark Boessenkool
  * @license     MIT
- * @since       2017-10-05
+ * @since       2019-09-03
  *
  */
 

--- a/tests/Models/OrderV2.php
+++ b/tests/Models/OrderV2.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Contains the Order model class.
+ *
+ * @copyright   Copyright (c) 2017 Attila Fulop
+ * @author      Attila Fulop
+ * @license     MIT
+ * @since       2017-10-05
+ *
+ */
+
+
+namespace Konekt\Enum\Eloquent\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Konekt\Enum\Eloquent\CastsEnums;
+
+class OrderV2 extends Model
+{
+    use CastsEnums;
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'is_active' => 'boolean'
+    ];
+
+    protected $enums = [
+        'status' => OrderStatusV2::class
+    ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+}

--- a/tests/Models/OrderV2.php
+++ b/tests/Models/OrderV2.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Contains the Order model class for Enum version 2 default
+ * Contains the Order model class for Enum version 2 default.
  *
  * @copyright   Copyright (c) 2017 Attila Fulop
  * @author      Mark Boessenkool

--- a/tests/Models/OrderVX.php
+++ b/tests/Models/OrderVX.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Contains the Order model class.
+ * Contains the Order model class for Enum version 2 and 3 default.
  *
  * @copyright   Copyright (c) 2017 Attila Fulop
- * @author      Attila Fulop
+ * @author      Mark Boessenkool
  * @license     MIT
- * @since       2017-10-05
+ * @since       2019-09-03
  *
  */
 

--- a/tests/Models/OrderVX.php
+++ b/tests/Models/OrderVX.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Contains the Order model class.
+ *
+ * @copyright   Copyright (c) 2017 Attila Fulop
+ * @author      Attila Fulop
+ * @license     MIT
+ * @since       2017-10-05
+ *
+ */
+
+
+namespace Konekt\Enum\Eloquent\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Konekt\Enum\Eloquent\CastsEnums;
+
+class OrderVX extends Model
+{
+    use CastsEnums;
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'is_active' => 'boolean'
+    ];
+
+    protected $enums = [
+        'status' => OrderStatusVX::class
+    ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function client()
+    {
+        return $this->belongsTo(Client::class);
+    }
+}


### PR DESCRIPTION
As discussed in #5 hereby a PR.

I do not have any knowledge of Travis, so I hope I did well on that part.

Made the Test Models so that most of them are backwards compatible. 
Only the Order one has a specific version check.

Added ocramius/package-versions to retrieve the version that is being used.

Also fixed the references to the old documentation.