### PR TITLE
Added support for Eloquent toArray()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 ### Konekt Enum Eloquent
 
+## 1.3.2
+##### 2019-09-17
+
+- Added support for Eloquent `toArray()`
+
 ## 1.3.1
 ##### 2019-09-08
 

--- a/src/CastsEnums.php
+++ b/src/CastsEnums.php
@@ -69,6 +69,16 @@ trait CastsEnums
     }
 
     /**
+     * Convert the model's attributes to an array.
+     *
+     * @return array
+     */
+    public function attributesToArray()
+    {
+        return $this->addEnumAttributesToArray(parent::attributesToArray());
+    }
+
+    /**
      * Returns whether the attribute was marked as enum
      *
      * @param $key
@@ -78,6 +88,19 @@ trait CastsEnums
     protected function isEnumAttribute($key)
     {
         return isset($this->enums[$key]);
+    }
+
+    /**
+     * Add enum values to the attributes array
+     *
+     * @param $array
+     * @return array
+     */
+    protected function addEnumAttributesToArray($array)
+    {
+        foreach ($this->enums as $key => $value) {
+            $array[$key] = $this->getAttributeValue($key);
+        }
     }
 
     /**

--- a/src/CastsEnums.php
+++ b/src/CastsEnums.php
@@ -99,8 +99,10 @@ trait CastsEnums
     protected function addEnumAttributesToArray($array)
     {
         foreach ($this->enums as $key => $value) {
-            $array[$key] = $this->getAttributeValue($key);
+            $array[$key] = $this->getAttributeValue($key)->value();
         }
+
+        return $array;
     }
 
     /**

--- a/tests/EnumToArrayTest.php
+++ b/tests/EnumToArrayTest.php
@@ -12,6 +12,7 @@
 namespace Konekt\Enum\Eloquent\Tests;
 
 use Konekt\Enum\Eloquent\Tests\Models\Order;
+use Konekt\Enum\Eloquent\Tests\Models\OrderV2;
 use Konekt\Enum\Eloquent\Tests\Models\OrderStatus;
 
 class EnumToArrayTest extends TestCase
@@ -99,7 +100,7 @@ class EnumToArrayTest extends TestCase
             return;
         }
 
-        $order = new Order([
+        $order = new OrderV2([
             'number' => 'abc123'
         ]);
 

--- a/tests/EnumToArrayTest.php
+++ b/tests/EnumToArrayTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Contains the EnumAccessorTest class.
+ *
+ * @copyright   Copyright (c) 2017 Attila Fulop
+ * @author      Attila Fulop
+ * @license     MIT
+ * @since       2017-10-05
+ *
+ */
+
+namespace Konekt\Enum\Eloquent\Tests;
+
+use Konekt\Enum\Eloquent\Tests\Models\Order;
+use Konekt\Enum\Eloquent\Tests\Models\OrderStatus;
+
+class EnumToArrayTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function returns_enum_string_value()
+    {
+        $order = new Order([
+            'number' => 'abc123',
+            'status' => OrderStatus::SUBMITTED
+        ]);
+
+        $array = $order->attributesToArray();
+
+        $this->assertArrayHasKey('status', $array);
+        $this->assertIsString($array['status']);
+    }
+
+    /**
+     * @test
+     */
+    public function still_returns_other_attributes()
+    {
+        $order = new Order([
+            'number' => 'abc123',
+            'status' => OrderStatus::SUBMITTED
+        ]);
+
+        $array = $order->attributesToArray();
+
+        $this->assertArrayHasKey('number', $array);
+        $this->assertEquals($array['number'], $order->number);
+    }
+
+    /**
+     * @test
+     */
+    public function to_array_still_works()
+    {
+        $order = new Order([
+            'number' => 'abc123',
+            'status' => OrderStatus::SUBMITTED
+        ]);
+
+        $attributesArray = $order->attributesToArray();
+        $array           = $order->toArray();
+
+        $this->assertEquals($array, $attributesArray);
+    }
+
+    /**
+     * @test
+     */
+    public function returns_enum_default_string_value_when_attribute_is_null()
+    {
+        // don't test if major version is lower than 3
+        if ($this->getEnumVersionMajor() < 3) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $order = new Order([
+            'number' => 'abc123'
+        ]);
+
+        $array = $order->attributesToArray();
+
+        $this->assertArrayHasKey('status', $array);
+        $this->assertIsString($array['status']);
+        $this->assertEquals($array['status'], OrderStatus::__DEFAULT);
+    }
+
+    /**
+     * @test
+     */
+    public function returns_enum_v2_default_string_value_when_attribute_is_null()
+    {
+        // don't test if major version is 3 or higher
+        if ($this->getEnumVersionMajor() >= 3) {
+            $this->assertTrue(true);
+
+            return;
+        }
+
+        $order = new Order([
+            'number' => 'abc123'
+        ]);
+
+        $array = $order->attributesToArray();
+
+        $this->assertArrayHasKey('status', $array);
+        $this->assertIsString($array['status']);
+        $this->assertEquals($array['status'], OrderStatus::__DEFAULT);
+    }
+
+    private function getEnumVersion()
+    {
+        $raw_version = \PackageVersions\Versions::getVersion('konekt/enum');
+
+        $parts = explode('@', $raw_version);
+
+        return $parts[0];
+    }
+
+    private function getEnumVersionMajor()
+    {
+        $parts = explode('.', $this->getEnumVersion());
+
+        return $parts[0];
+    }
+}


### PR DESCRIPTION
Hi there! I love this enum plugin you've made, and I've been using it on all of my recent Laravel projects. However, I noticed that the enum properties are left out entirely when calling a model's `toArray()` function.
In my update, I've overwritten one of the functions Eloquent uses to build this array and added support for the `enum` values stored in the CastsEnums trait. Tested on one of my local projects and it seems to work fine :)