### PR TITLE
Remove deprecated assertInternalType in tests

### DIFF
--- a/tests/EnumAccessorTest.php
+++ b/tests/EnumAccessorTest.php
@@ -116,7 +116,7 @@ class EnumAccessorTest extends TestCase
 
         $this->assertNotNull($order->id);
         $this->assertInstanceOf(\DateTime::class, $order->created_at);
-        $this->assertInternalType('boolean', $order->is_active);
+        $this->assertIsBool($order->is_active);
     }
 
     /**


### PR DESCRIPTION
Replace assertInternalType('boolean', ...) with assertIsBool(...) because it's been deprecated