### PR TITLE
Bugfix/eloquent visibility not used

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 ### Konekt Enum Eloquent
 
+## 1.10.0
+##### 2023-08-03
+
+- Fixed issue where CastEnum did not take in account hidden or visible properties from Eloquent
+
 ## 1.9.0
 ##### 2023-02-16
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 ### Konekt Enum Eloquent
 
-## 1.10.0
-##### 2023-08-03
+## Unreleased
+##### 2023-XX-YY
 
 - Fixed issue where CastEnum did not take in account hidden or visible properties from Eloquent
 

--- a/src/CastsEnums.php
+++ b/src/CastsEnums.php
@@ -81,7 +81,11 @@ trait CastsEnums
      */
     public function attributesToArray()
     {
-        return $this->addEnumAttributesToArray(parent::attributesToArray());
+        return $this->getArrayableItems(
+            $this->addEnumAttributesToArray(
+                parent::attributesToArray()
+            )
+        );
     }
 
     /**

--- a/tests/EnumToArrayTest.php
+++ b/tests/EnumToArrayTest.php
@@ -18,6 +18,8 @@ use Konekt\Enum\Eloquent\Tests\Models\Order;
 use Konekt\Enum\Eloquent\Tests\Models\OrderStatus;
 use Konekt\Enum\Eloquent\Tests\Models\OrderStatusV2;
 use Konekt\Enum\Eloquent\Tests\Models\OrderV2;
+use Konekt\Enum\Eloquent\Tests\Models\Visibility;
+use Konekt\Enum\Eloquent\Tests\Models\VisibilityTalk;
 
 class EnumToArrayTest extends TestCase
 {
@@ -128,5 +130,65 @@ class EnumToArrayTest extends TestCase
         $this->assertArrayHasKey('status', $array);
         $this->assertIsString($array['status']);
         $this->assertEquals($array['status'], OrderStatusV2::__default);
+    }
+
+    /** @test */
+    public function returns_no_enum_if_hidden()
+    {
+        $normal = new Visibility([
+            'number' => 'na321',
+            'talk1' => VisibilityTalk::BLABLA,
+            'talk2' => VisibilityTalk::YADDA,
+        ]);
+
+        $array = $normal->attributesToArray();
+
+        $this->assertArrayHasKey('number', $array);
+        $this->assertArrayNotHasKey('talk1', $array);
+        $this->assertArrayHasKey('talk2', $array);
+        $this->assertIsString($array['talk2']);
+        $this->assertEquals($array['talk2'], VisibilityTalk::YADDA);
+    }
+
+    /** @test */
+    public function returns_no_enum_if_hidden_dynamic()
+    {
+        $dynamic_hidden = new Visibility([
+            'number' => 'na654',
+            'talk1' => VisibilityTalk::BLABLA,
+            'talk2' => VisibilityTalk::YADDA,
+        ]);
+
+        $dynamic_hidden->makeHidden('talk2');
+
+        $array = $dynamic_hidden->attributesToArray();
+
+        $this->assertArrayHasKey('number', $array);
+        $this->assertArrayNotHasKey('talk1', $array);
+        $this->assertArrayNotHasKey('talk2', $array);
+    }
+
+    /** @test */
+    public function returns_enum_if_hidden_made_visible()
+    {
+        $made_visible = new Visibility([
+            'number' => 'na987',
+            'talk1' => VisibilityTalk::BLABLA,
+            'talk2' => VisibilityTalk::YADDA,
+        ]);
+
+        $made_visible->makeVisible('talk1');
+
+        $array = $made_visible->attributesToArray();
+
+        $this->assertArrayHasKey('number', $array);
+
+        $this->assertArrayHasKey('talk1', $array);
+        $this->assertIsString($array['talk1']);
+        $this->assertEquals($array['talk1'], VisibilityTalk::BLABLA);
+
+        $this->assertArrayHasKey('talk2', $array);
+        $this->assertIsString($array['talk2']);
+        $this->assertEquals($array['talk2'], VisibilityTalk::YADDA);
     }
 }

--- a/tests/Models/Visibility.php
+++ b/tests/Models/Visibility.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Contains the Order model class for Enum version 2 and 3 default.
+ *
+ * @copyright   Copyright (c) 2023 Mark Boessenkool
+ * @author      Mark Boessenkool
+ * @license     MIT
+ * @since       2023-08-02
+ *
+ */
+
+namespace Konekt\Enum\Eloquent\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Konekt\Enum\Eloquent\CastsEnums;
+
+class Visibility extends Model
+{
+    use CastsEnums;
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'is_active' => 'boolean'
+    ];
+
+    protected $enums = [
+        'talk1' => VisibilityTalk::class,
+        'talk2' => VisibilityTalk::class,
+    ];
+
+    protected $hidden = [
+        'talk1',
+    ];
+}

--- a/tests/Models/VisibilityTalk.php
+++ b/tests/Models/VisibilityTalk.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Contains the VisibilityTalk class
+ *
+ * @copyright   Copyright (c) 2023 Mark Boessenkool
+ * @author      Mark Boessenkool
+ * @license     MIT
+ * @since       2023-08-02
+ *
+ */
+
+namespace Konekt\Enum\Eloquent\Tests\Models;
+
+use Konekt\Enum\Enum;
+
+class VisibilityTalk extends Enum
+{
+    public const BLABLA = 'blabla';
+    public const YADDA = 'yadda';
+    public const ZIGZAG = 'zig zag';
+    public const PINGPONG = 'ping pong';
+}


### PR DESCRIPTION
## Summary

Currently if you would use the HiddenAttributes feature of Eloquent, the enums would still be visible.

This is because they are added after Eloquent hides attributes if needed.

With this change I executed the function to hide the attributes after the AddEnumAttributes was performed.

## Test Report

```text
❯ ./vendor/phpunit/phpunit/phpunit
PHPUnit 10.2.7 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.8
Configuration: ./enum-eloquent/phpunit.xml

...........................                                       27 / 27 (100%)

Time: 00:00.076, Memory: 14.00 MB

OK (27 tests, 58 assertions)
```

## StyleCI

As far as I can see everything should be good however, I was not able to run the StyleCI test myself.

Edit: saw that the build actions for the PR has a pass for StyleCI

## New Functionality Tests

- [x] In case you add new functionality, it must be covered by tests
